### PR TITLE
Add drushrc.php file to set URI automatically for CLI/cron

### DIFF
--- a/drushrc.php
+++ b/drushrc.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Example Drush configuration file for a Platform.sh Drupal site.
+ */
+
+if (PHP_SAPI === 'cli' && isset($_ENV['PLATFORM_ROUTES']) && isset($_ENV['PLATFORM_APPLICATION_NAME'])) {
+  $routes = json_decode(base64_decode($_ENV['PLATFORM_ROUTES']), TRUE);
+  $expected_route_urls = [
+    'https://{default}/',
+    'https://www.{default}/',
+    'http://{default}/',
+    'http://www.{default}/',
+  ];
+  foreach ($routes as $url => $route) {
+    if ($route['type'] === 'upstream'
+    	&& $route['upstream'] === $_ENV['PLATFORM_APPLICATION_NAME']
+    	&& in_array($route['original_url'], $expected_route_urls)) {
+      $options['uri'] = $url;
+      break;
+    }
+  }
+}


### PR DESCRIPTION
If you `cd public`, `drush status`, with this patch Drush should now show a Site URI of something like `https://test-pnjt4dy-o32n37yms7k2d.eu.platform.sh/` instead of `http://default`.

See this comment https://github.com/goalgorilla/platformsh-example-opensocial/pull/4#issuecomment-255053554 for a caveat.