### PR TITLE
Update `platform` module to fix environment name

### DIFF
--- a/project.make
+++ b/project.make
@@ -10,4 +10,4 @@ projects[drupal][patch][] = "https://drupal.org/files/issues/install-redirect-on
 defaults[projects][subdir] = contrib
 
 ; Platform indicator module.
-projects[platform][version] = 1.3
+projects[platform][version] = 1.4


### PR DESCRIPTION
See issue: http://drupal.org/node/2822488
- [x] Wait for 1.4 release to be generated/published by d.o
