### PR TITLE
Correcting typo: jss => js

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -77,7 +77,7 @@ web:
 
             rules:
                 # Provide a longer TTL (2 weeks) for aggregated CSS and JS files.
-                '^/sites/default/files/(css|jss)':
+                '^/sites/default/files/(css|js)':
                     expires: 2w
 
 # The size of the persistent disk of the application (in MB).


### PR DESCRIPTION
Self explanatory, really. 