### PR TITLE
Only bust the cache on Drupal session cookies.

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -6,6 +6,10 @@
 "https://{default}/":
     type: upstream
     upstream: "app:http"
+    cache:
+        enabled: true
+        # Base the cache on the session cookie. Ignore all other cookies.
+        cookies: ['/^SS?ESS/']
 
 "https://www.{default}/":
     type: redirect


### PR DESCRIPTION
We already have this setting in the Drupal 8 site, but we really should do the same on D7.