### PR TITLE
Always include settings.local.php

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -25,13 +25,15 @@ $drupal_hash_salt = '';
 // Set Drupal not to check for HTTP connectivity.
 $conf['drupal_http_request_fails'] = FALSE;
 
-// Include automatic Platform.sh settings.
-if (file_exists(__DIR__ . '/settings.platformsh.php')) {
+// Include local settings. 
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  require_once(__DIR__ . '/settings.local.php');
+}
+
+// Include special Platform.sh settings.
+// These come last so that they can override anything.
+$on_platformsh = getenv('PLATFORM_PROJECT') !== FALSE;
+if ($on_platformsh && file_exists(__DIR__ . '/settings.platformsh.php')) {
   require_once(__DIR__ . '/settings.platformsh.php');
 }
 
-// Include local settings. These come last so that they can override anything.
-$on_platformsh = getenv('PLATFORM_PROJECT') !== FALSE;
-if (file_exists(__DIR__ . '/settings.local.php') && !$on_platformsh) {
-  require_once(__DIR__ . '/settings.local.php');
-}

--- a/settings.php
+++ b/settings.php
@@ -25,7 +25,7 @@ $drupal_hash_salt = '';
 // Set Drupal not to check for HTTP connectivity.
 $conf['drupal_http_request_fails'] = FALSE;
 
-// Include local settings. 
+// Include local settings.
 if (file_exists(__DIR__ . '/settings.local.php')) {
   require_once(__DIR__ . '/settings.local.php');
 }


### PR DESCRIPTION
This is based on only a few minutes research, but I *think* the inclusion of settings.local.php and settings.platformsh.php should be reversed. AFAICT, the Platform build process puts the automatic database settings in a settings.local.php, whereas this file was only including it when *not* on Platform. 

When using the old version, I was landed in the Drupal installer. Using this change, everything seems to be working as it should.